### PR TITLE
Add pytest checks for blueprint inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,10 @@
 # home-assistant
-# home-assistant
+
+## Tests
+
+Install dependencies and run the tests using `pytest`:
+
+```bash
+pip install -r requirements.txt
+pytest
+```

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+pytest
+pyyaml

--- a/tests/test_blueprint_inputs.py
+++ b/tests/test_blueprint_inputs.py
@@ -1,0 +1,41 @@
+import os
+import yaml
+import pytest
+
+class InputTag(str):
+    pass
+
+class Loader(yaml.SafeLoader):
+    pass
+
+def input_constructor(loader, node):
+    return InputTag(loader.construct_scalar(node))
+
+Loader.add_constructor('!input', input_constructor)
+
+REPO_ROOT = os.path.dirname(os.path.dirname(__file__))
+YAML_FILES = [os.path.join(REPO_ROOT, f) for f in os.listdir(REPO_ROOT) if f.endswith('.yaml')]
+
+
+def collect_input_refs(data):
+    refs = []
+    if isinstance(data, InputTag):
+        refs.append(str(data))
+    elif isinstance(data, dict):
+        for value in data.values():
+            refs.extend(collect_input_refs(value))
+    elif isinstance(data, list):
+        for item in data:
+            refs.extend(collect_input_refs(item))
+    return refs
+
+@pytest.mark.parametrize('yaml_file', YAML_FILES)
+def test_inputs_defined(yaml_file):
+    with open(yaml_file, 'r', encoding='utf-8') as f:
+        data = yaml.load(f, Loader=Loader)
+    assert 'blueprint' in data, f"{yaml_file} lacks blueprint section"
+    blueprint_inputs = data['blueprint'].get('input', {})
+    defined_keys = set(blueprint_inputs.keys())
+    refs = collect_input_refs(data)
+    for ref in refs:
+        assert ref in defined_keys, f"{yaml_file}: !input {ref} not defined in blueprint.input"


### PR DESCRIPTION
## Summary
- add `pytest` and `pyyaml` dependencies
- document how to run tests
- add tests to verify `!input` references exist in each blueprint YAML

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685106d098b0832d80aa94e050542967