### PR TITLE
Update heating blueprint to use true/false inputs

### DIFF
--- a/Calefaccion.yaml
+++ b/Calefaccion.yaml
@@ -1,6 +1,6 @@
 blueprint:
   name: "Escena Condicional con Input Booleano"
-  description: "Activa una de dos escenas en función del estado de un input booleano."
+  description: "Activa una de dos escenas o acciones en función del estado de un input booleano. Si las entidades son booleanas, se establecerán en 'on' o 'off' según corresponda."
   domain: automation
   input:
     toggle_boolean:
@@ -14,7 +14,7 @@ blueprint:
             - domain: binary_sensor
     scene_true:
       name: "Acción cuando es True"
-      description: "Escena, script o entidad que se encenderá cuando el booleano esté en 'on'."
+      description: "Escena, script o entidad que se activará o se pondrá en 'on' cuando el booleano esté en 'on'."
       selector:
         entity:
           filter:
@@ -24,7 +24,7 @@ blueprint:
             - domain: switch
     scene_false:
       name: "Acción cuando es False"
-      description: "Escena, script o entidad que se apagará cuando el booleano esté en 'off'."
+      description: "Escena, script o entidad que se desactivará o se pondrá en 'off' cuando el booleano esté en 'off'."
       selector:
         entity:
           filter:
@@ -32,13 +32,6 @@ blueprint:
             - domain: script
             - domain: input_boolean
             - domain: switch
-    toggle_entities:
-      name: "Dispositivos a controlar"
-      description: "Entidades que se encenderán con 'on' y se apagarán con 'off'."
-      default: []
-      selector:
-        entity:
-          multiple: true
     delay_seconds:
       name: "Retraso en segundos"
       description: "Tiempo a esperar antes de ejecutar la acción."
@@ -67,18 +60,12 @@ action:
           - service: homeassistant.turn_on
             target:
               entity_id: !input scene_true
-          - service: homeassistant.turn_on
-            target:
-              entity_id: !input toggle_entities
       - conditions:
           - condition: state
             entity_id: !input toggle_boolean
             state: "off"
         sequence:
           - delay: !input delay_seconds
-          - service: homeassistant.turn_on
-            target:
-              entity_id: !input scene_false
           - service: homeassistant.turn_off
             target:
-              entity_id: !input toggle_entities
+              entity_id: !input scene_false


### PR DESCRIPTION
## Summary
- remove `toggle_entities` from `Calefaccion.yaml`
- have the blueprint switch the `scene_false` entity off
- update descriptions to explain boolean behaviour

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685db4a026a8832da6f98620e086d4e1