### PR TITLE
Add state checks before toggling climate devices

### DIFF
--- a/Climatizacion.yaml
+++ b/Climatizacion.yaml
@@ -82,6 +82,9 @@ action:
           - condition: numeric_state
             entity_id: !input sensor_temperatura
             above: !input temperatura_maxima
+          - condition: state
+            entity_id: "{{ enfriador_entity }}"
+            state: "off"
         sequence:
           - service: "{{ enfriador_domain }}.turn_on"
             target:
@@ -90,6 +93,9 @@ action:
           - condition: numeric_state
             entity_id: !input sensor_temperatura
             below: !input temperatura_minima
+          - condition: state
+            entity_id: "{{ enfriador_entity }}"
+            state: "on"
         sequence:
           - service: "{{ enfriador_domain }}.turn_off"
             target:
@@ -100,6 +106,9 @@ action:
           - condition: numeric_state
             entity_id: !input sensor_temperatura
             below: !input temperatura_minima
+          - condition: state
+            entity_id: "{{ calefaccion_entity }}"
+            state: "off"
         sequence:
           - service: "{{ calefaccion_domain }}.turn_on"
             target:
@@ -108,6 +117,9 @@ action:
           - condition: numeric_state
             entity_id: !input sensor_temperatura
             above: !input temperatura_maxima
+          - condition: state
+            entity_id: "{{ calefaccion_entity }}"
+            state: "on"
         sequence:
           - service: "{{ calefaccion_domain }}.turn_off"
             target:


### PR DESCRIPTION
## Summary
- avoid toggling cooler or heater if already in the desired state
- add conditions checking `off`/`on` state before issuing `turn_on`/`turn_off`

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6864358ef46c832d93a6953c5c2b3229