### PR TITLE
Support scenes and scripts in light blueprints

### DIFF
--- a/Luces.yaml
+++ b/Luces.yaml
@@ -14,10 +14,13 @@ blueprint:
 
     luces:
       name: Luces
-      description: "Selecciona las luces que se encenderán y apagarán automáticamente."
+      description: "Selecciona las luces, escenas o scripts que se activarán y desactivarán."
       selector:
         entity:
-          domain: light
+          filter:
+            - domain: light
+            - domain: scene
+            - domain: script
           multiple: true
 
     sensores_puerta:
@@ -96,6 +99,7 @@ action:
       sensores_puerta_var: !input sensores_puerta
       umbral_luz_var: !input umbral_luz
       tiempo_apagado_var: !input tiempo_apagado
+      luces_var: !input luces
 
   - choose:
       - conditions:
@@ -106,9 +110,14 @@ action:
               {{ sensores_luz_var | count == 0 or
                  (sensores_luz_var | map('states', 0) | map('float', 0) | min < umbral_luz_var) }}
         sequence:
-          - service: light.turn_on
-            target:
-              entity_id: !input luces
+          - repeat:
+              for_each: "{{ luces_var }}"
+              sequence:
+                - variables:
+                    current_domain: "{{ repeat.item.split('.')[0] }}"
+                - service: "{{ current_domain }}.turn_on"
+                  target:
+                    entity_id: "{{ repeat.item }}"
 
       - conditions:
           - condition: trigger
@@ -117,9 +126,23 @@ action:
             value_template: >
               {{ sensores_presencia_var | map('states') | select('eq', 'off') | list | count == sensores_presencia_var | count }}
         sequence:
-          - service: light.turn_off
-            target:
-              entity_id: !input luces
+          - repeat:
+              for_each: "{{ luces_var }}"
+              sequence:
+                - variables:
+                    current_domain: "{{ repeat.item.split('.')[0] }}"
+                - choose:
+                    - conditions:
+                        - condition: template
+                          value_template: "{{ current_domain in ['scene', 'script'] }}"
+                      sequence:
+                        - service: "{{ current_domain }}.turn_on"
+                          target:
+                            entity_id: "{{ repeat.item }}"
+                  default:
+                    - service: "{{ current_domain }}.turn_off"
+                      target:
+                        entity_id: "{{ repeat.item }}"
 
       - conditions:
           - condition: trigger
@@ -132,9 +155,14 @@ action:
               {{ sensores_luz_var | count == 0 or
                  (sensores_luz_var | map('states', 0) | map('float', 0) | min < umbral_luz_var) }}
         sequence:
-          - service: light.turn_on
-            target:
-              entity_id: !input luces
+          - repeat:
+              for_each: "{{ luces_var }}"
+              sequence:
+                - variables:
+                    current_domain: "{{ repeat.item.split('.')[0] }}"
+                - service: "{{ current_domain }}.turn_on"
+                  target:
+                    entity_id: "{{ repeat.item }}"
 
       - conditions:
           - condition: trigger
@@ -145,6 +173,20 @@ action:
               {{ sensores_presencia_var | map('states') | select('eq', 'off') | list | count == sensores_presencia_var | count and
                  ((as_timestamp(now()) - min_last_changed) / 60) >= tiempo_apagado_var }}
         sequence:
-          - service: light.turn_off
-            target:
-              entity_id: !input luces
+          - repeat:
+              for_each: "{{ luces_var }}"
+              sequence:
+                - variables:
+                    current_domain: "{{ repeat.item.split('.')[0] }}"
+                - choose:
+                    - conditions:
+                        - condition: template
+                          value_template: "{{ current_domain in ['scene', 'script'] }}"
+                      sequence:
+                        - service: "{{ current_domain }}.turn_on"
+                          target:
+                            entity_id: "{{ repeat.item }}"
+                  default:
+                    - service: "{{ current_domain }}.turn_off"
+                      target:
+                        entity_id: "{{ repeat.item }}"

--- a/LucesCuarto.yaml
+++ b/LucesCuarto.yaml
@@ -14,11 +14,14 @@ blueprint:
 
     luces:
       name: Luces
-      description: "Selecciona las luces que se encenderán y apagarán automáticamente."
+      description: "Selecciona las luces, escenas o scripts que se activarán y desactivarán."
       default: []
       selector:
         entity:
-          domain: light
+          filter:
+            - domain: light
+            - domain: scene
+            - domain: script
           multiple: true
 
     sensores_puerta:
@@ -111,17 +114,36 @@ action:
               {{ sensores_luz_var | count == 0 or
                  (sensores_luz_var | map('states', 0) | map('float', 0) | min < umbral_luz_var) }}
         sequence:
-          - service: light.turn_on
-            target:
-              entity_id: !input luces
+          - repeat:
+              for_each: "{{ luces_var }}"
+              sequence:
+                - variables:
+                    current_domain: "{{ repeat.item.split('.')[0] }}"
+                - service: "{{ current_domain }}.turn_on"
+                  target:
+                    entity_id: "{{ repeat.item }}"
 
       - conditions:
           - condition: trigger
             id: "sin_presencia"
         sequence:
-          - service: light.turn_off
-            target:
-              entity_id: !input luces
+          - repeat:
+              for_each: "{{ luces_var }}"
+              sequence:
+                - variables:
+                    current_domain: "{{ repeat.item.split('.')[0] }}"
+                - choose:
+                    - conditions:
+                        - condition: template
+                          value_template: "{{ current_domain in ['scene', 'script'] }}"
+                      sequence:
+                        - service: "{{ current_domain }}.turn_on"
+                          target:
+                            entity_id: "{{ repeat.item }}"
+                  default:
+                    - service: "{{ current_domain }}.turn_off"
+                      target:
+                        entity_id: "{{ repeat.item }}"
 
       - conditions:
           - condition: trigger
@@ -130,6 +152,20 @@ action:
             value_template: >
               {{ trigger.event.data.device_id in interruptor_estado_var }}
         sequence:
-          - service: light.toggle
-            target:
-              entity_id: !input luces
+          - repeat:
+              for_each: "{{ luces_var }}"
+              sequence:
+                - variables:
+                    current_domain: "{{ repeat.item.split('.')[0] }}"
+                - choose:
+                    - conditions:
+                        - condition: template
+                          value_template: "{{ current_domain in ['scene', 'script'] }}"
+                      sequence:
+                        - service: "{{ current_domain }}.turn_on"
+                          target:
+                            entity_id: "{{ repeat.item }}"
+                  default:
+                    - service: "{{ current_domain }}.toggle"
+                      target:
+                        entity_id: "{{ repeat.item }}"


### PR DESCRIPTION
## Summary
- allow `Luces.yaml` and `LucesCuarto.yaml` to accept scenes and scripts as light inputs
- toggle/turn lights by looping through each entity and calling the proper service

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686de94d85ac832dbb2f3a9c910e3bae