### PR TITLE
Fix clima blueprint number selector

### DIFF
--- a/Climatizacion.yaml
+++ b/Climatizacion.yaml
@@ -46,7 +46,6 @@ blueprint:
           min: 0
           max: 10
           step: 0.1
-          unit_of_measurement: "°C"
     sensores_presencia:
       name: Sensores de presencia
       description: Sensores o grupos que indican si hay alguien presente.


### PR DESCRIPTION
## Summary
- remove the unsupported unit_of_measurement field from the diferencia_activacion number selector in Climatizacion blueprint to allow import

## Testing
- pytest -q --disable-warnings --maxfail=1

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6920bd7d1cc0832da49e3f9d12952bf1)